### PR TITLE
Update Header.jsx wrong className for welcome image

### DIFF
--- a/src/container/Header/Header.jsx
+++ b/src/container/Header/Header.jsx
@@ -13,7 +13,7 @@ const Header = () => (
       <button type="button" className="custom__button">Explore Menu</button>
     </div>
 
-    <div className="app__wrapper_img">
+    <div className="app__header-img">
       <img src={images.welcome} alt="header_img" />
     </div>
   </div>


### PR DESCRIPTION
The className in the CSS for the image width of 80% is app__header-img and not the original app__wrapper_img needs update the salmon is too big otherwise